### PR TITLE
Initialize basic task framework

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,6 @@
+// src/config.js
+// Global configuration for the colony
+
+module.exports = {
+  STALL_TICKS_THRESHOLD: 5
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+const colony = require('managers.colony');
+
 module.exports.loop = function () {
-  console.log('Main loop running...');
+  colony.run();
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const colony = require('managers.colony');
+const colony = require('managers_colony');
 
 module.exports.loop = function () {
   colony.run();

--- a/src/managers/colony.js
+++ b/src/managers/colony.js
@@ -1,0 +1,10 @@
+const roomManager = require('managers.room');
+
+module.exports = {
+  run() {
+    for (const name in Game.rooms) {
+      const room = Game.rooms[name];
+      roomManager.run(room);
+    }
+  }
+};

--- a/src/managers/colony.js
+++ b/src/managers/colony.js
@@ -1,4 +1,4 @@
-const roomManager = require('managers.room');
+const roomManager = require('managers_room');
 
 module.exports = {
   run() {

--- a/src/managers/creep.js
+++ b/src/managers/creep.js
@@ -1,0 +1,19 @@
+const tasks = {
+  harvest: require('tasks.harvest'),
+  build: require('tasks.build'),
+  haul: require('tasks.haul'),
+  upgrade: require('tasks.upgrade'),
+  repair: require('tasks.repair')
+};
+
+module.exports = {
+  run(creep) {
+    const taskName = creep.memory.task;
+    const task = tasks[taskName];
+    if (task && typeof task.run === 'function') {
+      task.run(creep);
+    } else {
+      creep.say('idle');
+    }
+  }
+};

--- a/src/managers/creep.js
+++ b/src/managers/creep.js
@@ -1,9 +1,9 @@
 const tasks = {
-  harvest: require('tasks.harvest'),
-  build: require('tasks.build'),
-  haul: require('tasks.haul'),
-  upgrade: require('tasks.upgrade'),
-  repair: require('tasks.repair')
+  harvest: require('tasks_harvest'),
+  build: require('tasks_build'),
+  haul: require('tasks_haul'),
+  upgrade: require('tasks_upgrade'),
+  repair: require('tasks_repair')
 };
 
 module.exports = {

--- a/src/managers/room.js
+++ b/src/managers/room.js
@@ -1,5 +1,5 @@
-const spawnManager = require('managers.spawn');
-const creepManager = require('managers.creep');
+const spawnManager = require('managers_spawn');
+const creepManager = require('managers_creep');
 
 module.exports = {
   run(room) {

--- a/src/managers/room.js
+++ b/src/managers/room.js
@@ -1,0 +1,12 @@
+const spawnManager = require('managers.spawn');
+const creepManager = require('managers.creep');
+
+module.exports = {
+  run(room) {
+    spawnManager.run();
+    for (const name in Game.creeps) {
+      const creep = Game.creeps[name];
+      creepManager.run(creep);
+    }
+  }
+};

--- a/src/managers/spawn.js
+++ b/src/managers/spawn.js
@@ -1,0 +1,13 @@
+module.exports = {
+  run() {
+    const spawn = Game.spawns['Spawn1'];
+    if (!spawn || spawn.spawning) return;
+
+    const workers = _.filter(Game.creeps, c => c.memory.role === 'worker');
+    if (workers.length < 4) {
+      spawn.spawnCreep([WORK, CARRY, MOVE], `worker_${Game.time}`, {
+        memory: { role: 'worker', task: 'harvest' }
+      });
+    }
+  }
+};

--- a/src/managers/taskManager.js
+++ b/src/managers/taskManager.js
@@ -1,0 +1,21 @@
+// src/managers/taskManager.js
+// Centralized task manager for assigning tasks to creeps
+
+module.exports = {
+  assignTask(creep) {
+    // Prefer hauling if storage/terminal exists and not full
+    if ((creep.room.storage && creep.room.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) ||
+        (creep.room.terminal && creep.room.terminal.store.getFreeCapacity(RESOURCE_ENERGY) > 0)) {
+      creep.memory.task = 'haul';
+      return;
+    }
+    // Assign building if there are construction sites
+    const site = creep.room.find(FIND_CONSTRUCTION_SITES)[0];
+    if (site) {
+      creep.memory.task = 'build';
+      return;
+    }
+    // Default to upgrading
+    creep.memory.task = 'upgrade';
+  }
+};

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -1,0 +1,12 @@
+module.exports = {
+  run(creep) {
+    const target = creep.pos.findClosestByPath(FIND_CONSTRUCTION_SITES);
+    if (target) {
+      if (creep.build(target) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+      }
+    } else {
+      creep.say('No build');
+    }
+  }
+};

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -1,12 +1,36 @@
+const config = require('./config');
+
 module.exports = {
-  run(creep) {
+  run(creep, taskManager) {
+    // --- Stall detection based on build progress ---
+    const posKey = `${creep.pos.x},${creep.pos.y}`;
     const target = creep.pos.findClosestByPath(FIND_CONSTRUCTION_SITES);
-    if (target) {
-      if (creep.build(target) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
-      }
+    const progressKey = target ? target.progress : null;
+    if (!creep.memory.lastPos || creep.memory.lastPos !== posKey || creep.memory.lastProgress !== progressKey) {
+      creep.memory.lastPos = posKey;
+      creep.memory.lastProgress = progressKey;
+      creep.memory.stallTicks = 0;
     } else {
-      creep.say('No build');
+      creep.memory.stallTicks = (creep.memory.stallTicks || 0) + 1;
+    }
+    if (creep.memory.stallTicks > config.STALL_TICKS_THRESHOLD) {
+      if (taskManager) taskManager.assignTask(creep);
+      creep.memory.stallTicks = 0;
+      return;
+    }
+    // End condition: out of energy
+    if (creep.store[RESOURCE_ENERGY] === 0) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // End condition: no construction sites
+    if (!target) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // Try to build
+    if (creep.build(target) === ERR_NOT_IN_RANGE) {
+      creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
     }
   }
 };

--- a/src/tasks/harvest.js
+++ b/src/tasks/harvest.js
@@ -1,5 +1,22 @@
 module.exports = {
   run(creep) {
+    // If creep is full, decide next task based on room state
+    if (creep.store.getFreeCapacity() === 0) {
+      // Prefer hauling if storage/terminal exists
+      if (creep.room.storage || creep.room.terminal) {
+        creep.memory.task = 'haul';
+      } else {
+        // If there are construction sites, build
+        const site = creep.room.find(FIND_CONSTRUCTION_SITES)[0];
+        if (site) {
+          creep.memory.task = 'build';
+        } else {
+          // Otherwise, upgrade controller
+          creep.memory.task = 'upgrade';
+        }
+      }
+      return;
+    }
     if (creep.store.getFreeCapacity() > 0) {
       const source = creep.pos.findClosestByPath(FIND_SOURCES_ACTIVE);
       if (source) {

--- a/src/tasks/harvest.js
+++ b/src/tasks/harvest.js
@@ -1,5 +1,22 @@
+const config = require('./config');
+
 module.exports = {
-  run(creep) {
+  run(creep, taskManager) {
+    // --- Stall detection based on carried energy ---
+    const posKey = `${creep.pos.x},${creep.pos.y}`;
+    const progressKey = creep.store[RESOURCE_ENERGY];
+    if (!creep.memory.lastPos || creep.memory.lastPos !== posKey || creep.memory.lastProgress !== progressKey) {
+      creep.memory.lastPos = posKey;
+      creep.memory.lastProgress = progressKey;
+      creep.memory.stallTicks = 0;
+    } else {
+      creep.memory.stallTicks = (creep.memory.stallTicks || 0) + 1;
+    }
+    if (creep.memory.stallTicks > config.STALL_TICKS_THRESHOLD) {
+      if (taskManager) taskManager.assignTask(creep);
+      creep.memory.stallTicks = 0;
+      return;
+    }
     // If creep is full, decide next task based on room state
     if (creep.store.getFreeCapacity() === 0) {
       // Prefer hauling if storage/terminal exists

--- a/src/tasks/harvest.js
+++ b/src/tasks/harvest.js
@@ -1,0 +1,12 @@
+module.exports = {
+  run(creep) {
+    if (creep.store.getFreeCapacity() > 0) {
+      const source = creep.pos.findClosestByPath(FIND_SOURCES_ACTIVE);
+      if (source) {
+        if (creep.harvest(source) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(source, {visualizePathStyle: {stroke: '#ffaa00'}});
+        }
+      }
+    }
+  }
+};

--- a/src/tasks/haul.js
+++ b/src/tasks/haul.js
@@ -1,19 +1,36 @@
+const config = require('./config');
+
 module.exports = {
-  run(creep) {
-    if (creep.store.getFreeCapacity() === 0) {
-      const target = creep.room.storage || creep.room.terminal;
-      if (target) {
-        if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-          creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
-        }
-      }
+  run(creep, taskManager) {
+    // --- Stall detection based on carried energy ---
+    const posKey = `${creep.pos.x},${creep.pos.y}`;
+    const progressKey = creep.store[RESOURCE_ENERGY];
+    if (!creep.memory.lastPos || creep.memory.lastPos !== posKey || creep.memory.lastProgress !== progressKey) {
+      creep.memory.lastPos = posKey;
+      creep.memory.lastProgress = progressKey;
+      creep.memory.stallTicks = 0;
     } else {
-      const source = creep.pos.findClosestByPath(FIND_DROPPED_RESOURCES);
-      if (source) {
-        if (creep.pickup(source) === ERR_NOT_IN_RANGE) {
-          creep.moveTo(source, {visualizePathStyle: {stroke: '#ffaa00'}});
-        }
-      }
+      creep.memory.stallTicks = (creep.memory.stallTicks || 0) + 1;
+    }
+    if (creep.memory.stallTicks > config.STALL_TICKS_THRESHOLD) {
+      if (taskManager) taskManager.assignTask(creep);
+      creep.memory.stallTicks = 0;
+      return;
+    }
+    // End condition: out of energy
+    if (creep.store[RESOURCE_ENERGY] === 0) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // End condition: nothing to haul to
+    const target = creep.room.storage || creep.room.terminal;
+    if (!target) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // Try to transfer energy
+    if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+      creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
     }
   }
 };

--- a/src/tasks/haul.js
+++ b/src/tasks/haul.js
@@ -1,0 +1,19 @@
+module.exports = {
+  run(creep) {
+    if (creep.store.getFreeCapacity() === 0) {
+      const target = creep.room.storage || creep.room.terminal;
+      if (target) {
+        if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+        }
+      }
+    } else {
+      const source = creep.pos.findClosestByPath(FIND_DROPPED_RESOURCES);
+      if (source) {
+        if (creep.pickup(source) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(source, {visualizePathStyle: {stroke: '#ffaa00'}});
+        }
+      }
+    }
+  }
+};

--- a/src/tasks/repair.js
+++ b/src/tasks/repair.js
@@ -1,0 +1,12 @@
+module.exports = {
+  run(creep) {
+    const target = creep.pos.findClosestByPath(FIND_STRUCTURES, {
+      filter: structure => structure.hits < structure.hitsMax
+    });
+    if (target) {
+      if (creep.repair(target) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+      }
+    }
+  }
+};

--- a/src/tasks/repair.js
+++ b/src/tasks/repair.js
@@ -1,12 +1,38 @@
+const config = require('./config');
+
 module.exports = {
-  run(creep) {
+  run(creep, taskManager) {
+    // --- Stall detection based on structure hits ---
+    const posKey = `${creep.pos.x},${creep.pos.y}`;
     const target = creep.pos.findClosestByPath(FIND_STRUCTURES, {
       filter: structure => structure.hits < structure.hitsMax
     });
-    if (target) {
-      if (creep.repair(target) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
-      }
+    const progressKey = target ? target.hits : null;
+    if (!creep.memory.lastPos || creep.memory.lastPos !== posKey || creep.memory.lastProgress !== progressKey) {
+      creep.memory.lastPos = posKey;
+      creep.memory.lastProgress = progressKey;
+      creep.memory.stallTicks = 0;
+    } else {
+      creep.memory.stallTicks = (creep.memory.stallTicks || 0) + 1;
+    }
+    if (creep.memory.stallTicks > config.STALL_TICKS_THRESHOLD) {
+      if (taskManager) taskManager.assignTask(creep);
+      creep.memory.stallTicks = 0;
+      return;
+    }
+    // End condition: out of energy
+    if (creep.store[RESOURCE_ENERGY] === 0) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // End condition: nothing to repair
+    if (!target) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // Try to repair
+    if (creep.repair(target) === ERR_NOT_IN_RANGE) {
+      creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
     }
   }
 };

--- a/src/tasks/upgrade.js
+++ b/src/tasks/upgrade.js
@@ -1,7 +1,35 @@
+const config = require('./config');
+
 module.exports = {
-  run(creep) {
-    if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
-      creep.moveTo(creep.room.controller, {visualizePathStyle: {stroke: '#ffffff'}});
+  run(creep, taskManager) {
+    // --- Stall detection based on controller progress ---
+    const posKey = `${creep.pos.x},${creep.pos.y}`;
+    const ctrl = creep.room.controller;
+    const progressKey = ctrl ? ctrl.progress : null;
+    if (!creep.memory.lastPos || creep.memory.lastPos !== posKey || creep.memory.lastProgress !== progressKey) {
+      creep.memory.lastPos = posKey;
+      creep.memory.lastProgress = progressKey;
+      creep.memory.stallTicks = 0;
+    } else {
+      creep.memory.stallTicks = (creep.memory.stallTicks || 0) + 1;
+    }
+    if (creep.memory.stallTicks > config.STALL_TICKS_THRESHOLD) {
+      if (taskManager) taskManager.assignTask(creep);
+      creep.memory.stallTicks = 0;
+      return;
+    }
+    // --- End conditions ---
+    if (creep.store[RESOURCE_ENERGY] === 0) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    if (!ctrl || ctrl.level === 8) {
+      if (taskManager) taskManager.assignTask(creep);
+      return;
+    }
+    // Try to upgrade
+    if (creep.upgradeController(ctrl) === ERR_NOT_IN_RANGE) {
+      creep.moveTo(ctrl, {visualizePathStyle: {stroke: '#ffffff'}});
     }
   }
 };

--- a/src/tasks/upgrade.js
+++ b/src/tasks/upgrade.js
@@ -1,0 +1,7 @@
+module.exports = {
+  run(creep) {
+    if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
+      creep.moveTo(creep.room.controller, {visualizePathStyle: {stroke: '#ffffff'}});
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement a simple task-based structure
- add manager modules to run creeps and spawn them
- update `main.js` to invoke colony manager

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876b2e550748328ae37e6f46e7da892