### PR TITLE
Implement BFS-based scouting

### DIFF
--- a/src/managers/creep.js
+++ b/src/managers/creep.js
@@ -3,7 +3,8 @@ const tasks = {
   build: require('tasks_build'),
   haul: require('tasks_haul'),
   upgrade: require('tasks_upgrade'),
-  repair: require('tasks_repair')
+  repair: require('tasks_repair'),
+  scout: require('tasks_scout')
 };
 
 module.exports = {

--- a/src/managers/spawn.js
+++ b/src/managers/spawn.js
@@ -3,6 +3,14 @@ module.exports = {
     const spawn = Game.spawns['Spawn1'];
     if (!spawn || spawn.spawning) return;
 
+    const scouts = _.filter(Game.creeps, c => c.memory.role === 'scout');
+    if (scouts.length < 1) {
+      spawn.spawnCreep([MOVE], `scout_${Game.time}`, {
+        memory: { role: 'scout', task: 'scout' }
+      });
+      return;
+    }
+
     const workers = _.filter(Game.creeps, c => c.memory.role === 'worker');
     if (workers.length < 4) {
       spawn.spawnCreep([WORK, CARRY, MOVE], `worker_${Game.time}`, {

--- a/src/tasks/scout.js
+++ b/src/tasks/scout.js
@@ -1,0 +1,59 @@
+module.exports = {
+  run(creep) {
+    if (!Memory.scouting) {
+      Memory.scouting = {
+        queue: [creep.room.name],
+        visited: {},
+        tags: {}
+      };
+    }
+
+    const scouting = Memory.scouting;
+
+    if (!creep.memory.targetRoom) {
+      creep.memory.targetRoom = scouting.queue[0];
+    }
+
+    if (!creep.memory.targetRoom) return;
+
+    if (creep.room.name !== creep.memory.targetRoom) {
+      creep.moveTo(new RoomPosition(25, 25, creep.memory.targetRoom), {
+        visualizePathStyle: { stroke: '#00ff00' }
+      });
+      return;
+    }
+
+    // Arrived in target room
+    if (!scouting.visited[creep.room.name]) {
+      scouting.visited[creep.room.name] = true;
+
+      let tag = 'empty';
+      const room = creep.room;
+      if (room.controller) {
+        if (room.controller.my) {
+          tag = 'owned';
+        } else if (!room.controller.owner) {
+          tag = 'claimable';
+        } else {
+          tag = 'hostile';
+        }
+      } else if (room.find(FIND_HOSTILE_CREEPS).length) {
+        tag = 'hostile';
+      }
+      scouting.tags[room.name] = tag;
+
+      const exits = Game.map.describeExits(room.name);
+      for (const dir in exits) {
+        const r = exits[dir];
+        if (!scouting.visited[r] && !scouting.queue.includes(r)) {
+          scouting.queue.push(r);
+        }
+      }
+    }
+
+    if (scouting.queue[0] === creep.room.name) {
+      scouting.queue.shift();
+    }
+    creep.memory.targetRoom = scouting.queue[0];
+  }
+};


### PR DESCRIPTION
## Summary
- spawn dedicated scout creeps
- give creeps a scout task
- store BFS queue in memory to scout nearby rooms first
- tag rooms in memory as owned, hostile, claimable, or empty

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687701c5bfb08328a6aea66b024616f1