### PR TITLE
Add stepwise wall repair logic

### DIFF
--- a/src/managers/taskDistribution.js
+++ b/src/managers/taskDistribution.js
@@ -1,0 +1,35 @@
+const UPGRADE_RATIO = 0.5;
+const REPAIR_RATIO = 0.3;
+
+module.exports = {
+  /**
+   * Choose next task for a worker creep based on desired ratios and room needs.
+   * @param {Room} room
+   * @returns {string} task name
+   */
+  chooseTask(room) {
+    const workers = _.filter(Game.creeps, c => c.memory.role === 'worker');
+    const upgradeCount = _.sum(workers, c => c.memory.task === 'upgrade');
+    const repairCount = _.sum(workers, c => c.memory.task === 'repair');
+    const total = workers.length || 1; // avoid divide by zero
+
+    const upgradeTarget = Math.floor(total * UPGRADE_RATIO);
+    const repairTarget = Math.floor(total * REPAIR_RATIO);
+
+    const hasRepairs = room.find(FIND_STRUCTURES, {
+      filter: s => s.hits < s.hitsMax &&
+        s.structureType !== STRUCTURE_WALL &&
+        s.structureType !== STRUCTURE_RAMPART
+    }).length > 0 ||
+    room.find(FIND_STRUCTURES, {
+      filter: s => (s.structureType === STRUCTURE_WALL || s.structureType === STRUCTURE_RAMPART) && s.hits < s.hitsMax
+    }).length > 0;
+
+    const hasConstruction = room.find(FIND_CONSTRUCTION_SITES).length > 0;
+
+    if (hasConstruction) return 'build';
+    if (hasRepairs && repairCount < repairTarget) return 'repair';
+    if (upgradeCount < upgradeTarget) return 'upgrade';
+    return hasRepairs ? 'repair' : 'upgrade';
+  }
+};

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -1,3 +1,5 @@
+const taskDistribution = require('managers_taskDistribution');
+
 module.exports = {
   run(creep) {
     // If out of energy, go harvest
@@ -8,11 +10,11 @@ module.exports = {
     const target = creep.pos.findClosestByPath(FIND_CONSTRUCTION_SITES);
     if (target) {
       if (creep.build(target) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+        creep.moveTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
       }
     } else {
-      // No construction sites, switch to upgrading
-      creep.memory.task = 'upgrade';
+      // No construction sites - pick another task based on workforce ratios
+      creep.memory.task = taskDistribution.chooseTask(creep.room);
     }
   }
 };

--- a/src/tasks/haul.js
+++ b/src/tasks/haul.js
@@ -1,19 +1,22 @@
+const taskDistribution = require('managers_taskDistribution');
+
 module.exports = {
   run(creep) {
     // If creep has energy, transfer to spawn/extensions first
     if (creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
       const target = creep.pos.findClosestByPath(FIND_STRUCTURES, {
         filter: structure =>
-          (structure.structureType === STRUCTURE_SPAWN || structure.structureType === STRUCTURE_EXTENSION) &&
+          (structure.structureType === STRUCTURE_SPAWN ||
+            structure.structureType === STRUCTURE_EXTENSION) &&
           structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
       });
       if (target) {
         if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-          creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+          creep.moveTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
         }
       } else {
-        // No structures need energy, switch to building
-        creep.memory.task = 'build';
+        // Nothing needs energy - choose next productive task
+        creep.memory.task = taskDistribution.chooseTask(creep.room);
       }
     } else {
       // No energy to haul, go harvest

--- a/src/tasks/repair.js
+++ b/src/tasks/repair.js
@@ -1,3 +1,5 @@
+const wallRampStep = 1000; // repair walls/ramparts in this increment
+
 module.exports = {
   run(creep) {
     // If empty, go harvest
@@ -5,17 +7,43 @@ module.exports = {
       creep.memory.task = 'harvest';
       return;
     }
-    // existing repair logic
+
+    // Repair non-wall structures first
     const target = creep.pos.findClosestByPath(FIND_STRUCTURES, {
-      filter: structure => structure.hits < structure.hitsMax
+      filter: structure =>
+        structure.hits < structure.hitsMax &&
+        structure.structureType !== STRUCTURE_WALL &&
+        structure.structureType !== STRUCTURE_RAMPART
     });
+
     if (target) {
       if (creep.repair(target) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(target, {visualizePathStyle: {stroke: '#ffffff'}});
+        creep.moveTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
       }
-    } else {
-      // No repair targets, switch to upgrading
-      creep.memory.task = 'upgrade';
+      return;
     }
+
+    // Handle walls and ramparts together, step wise
+    const walls = creep.room.find(FIND_STRUCTURES, {
+      filter: s => s.structureType === STRUCTURE_WALL || s.structureType === STRUCTURE_RAMPART
+    });
+
+    if (walls.length > 0) {
+      const minHits = Math.min(...walls.map(w => w.hits));
+      const threshold = minHits + wallRampStep;
+      const wallTarget = creep.pos.findClosestByPath(walls, {
+        filter: s => s.hits < Math.min(threshold, s.hitsMax)
+      });
+      if (wallTarget) {
+        if (creep.repair(wallTarget) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(wallTarget, { visualizePathStyle: { stroke: '#ffffff' } });
+        }
+        return;
+      }
+    }
+
+    // Nothing left to repair - pick another task
+    const taskDistribution = require('managers_taskDistribution');
+    creep.memory.task = taskDistribution.chooseTask(creep.room);
   }
 };


### PR DESCRIPTION
## Summary
- upgrade repair task logic
- prioritize normal structures then handle walls and ramparts in increments
- route from haul/build/repair into a new task distribution manager
- distribute workers across upgrade and repair tasks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687832bf77788328ae7b3db9be1f5cd3