### PR TITLE
Add structure manager

### DIFF
--- a/src/managers/room.js
+++ b/src/managers/room.js
@@ -1,6 +1,6 @@
 const spawnManager = require('managers_spawn');
 const creepManager = require('managers_creep');
-const turret = require('structures_turret');
+const structureManager = require('managers_structure');
 
 module.exports = {
   run(room) {
@@ -66,12 +66,7 @@ module.exports = {
       const creep = Game.creeps[name];
       creepManager.run(creep);
     }
-    // run turret logic
-    if (room.controller && room.controller.my) {
-      const turrets = room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === STRUCTURE_TOWER });
-      for (const turretObj of turrets) {
-        turret.run(turretObj);
-      }
-    }
+    // manage structures in the room
+    structureManager.run(room);
   }
 };

--- a/src/managers/structure.js
+++ b/src/managers/structure.js
@@ -1,0 +1,14 @@
+const turret = require('structures_turret');
+
+module.exports = {
+  run(room) {
+    if (room.controller && room.controller.my) {
+      const turrets = room.find(FIND_MY_STRUCTURES, {
+        filter: s => s.structureType === STRUCTURE_TOWER
+      });
+      for (const turretObj of turrets) {
+        turret.run(turretObj);
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- centralize structure handling by adding a new `structure` manager
- call the structure manager from the room manager

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688109b18e24832881ba8568b75394e2